### PR TITLE
Added frictionAngle Matchmaker to cohesive frictional contact law 

### DIFF
--- a/pkg/dem/CohesiveFrictionalContactLaw.cpp
+++ b/pkg/dem/CohesiveFrictionalContactLaw.cpp
@@ -260,8 +260,9 @@ void Ip2_CohFrictMat_CohFrictMat_CohFrictPhys::go(const shared_ptr<Material>& b1
 			Real Vb 	= sdec2->poisson;
 			Real Da 	= geom->radius1;
 			Real Db 	= geom->radius2;
-			Real fa 	= sdec1->frictionAngle;
-			Real fb 	= sdec2->frictionAngle;
+			// Real fa 	= sdec1->frictionAngle;
+			// Real fb 	= sdec2->frictionAngle;
+			Real frictionAngle = (!frictAngle) ? std::min(sdec1->frictionAngle,sdec2->frictionAngle) : (*frictAngle)(sdec1->id,sdec2->id,sdec1->frictionAngle,sdec2->frictionAngle); // modified in accordance to FrictPhys.cpp
 			Real Kn = 2.0*Ea*Da*Eb*Db/(Ea*Da+Eb*Db);//harmonic average of two stiffnesses
 
 			// harmonic average of alphas parameters
@@ -277,7 +278,8 @@ void Ip2_CohFrictMat_CohFrictMat_CohFrictPhys::go(const shared_ptr<Material>& b1
 
 			contactPhysics->kr = Da*Db*Ks*AlphaKr;
 			contactPhysics->ktw = Da*Db*Ks*AlphaKtw;
-			contactPhysics->tangensOfFrictionAngle		= std::tan(std::min(fa,fb));
+			// contactPhysics->tangensOfFrictionAngle = std::tan(std::min(fa,fb));
+			contactPhysics->tangensOfFrictionAngle = std::tan(frictionAngle); //  modified in accordance to FrictPhys.cpp
 
 			if ((setCohesionOnNewContacts || setCohesionNow) && sdec1->isCohesive && sdec2->isCohesive)
 			{

--- a/pkg/dem/CohesiveFrictionalContactLaw.hpp
+++ b/pkg/dem/CohesiveFrictionalContactLaw.hpp
@@ -149,6 +149,7 @@ class Ip2_CohFrictMat_CohFrictMat_CohFrictPhys : public IPhysFunctor
 		((bool,setCohesionOnNewContacts,false,,"If true, assign cohesion at all new contacts. If false, only existing contacts can be cohesive (also see :yref:`Ip2_CohFrictMat_CohFrictMat_CohFrictPhys::setCohesionNow`), and new contacts are only frictional."))	
 		((shared_ptr<MatchMaker>,normalCohesion,,,"Instance of :yref:`MatchMaker` determining tensile strength"))
 		((shared_ptr<MatchMaker>,shearCohesion,,,"Instance of :yref:`MatchMaker` determining cohesive part of the shear strength (a frictional term might be added depending on :yref:`CohFrictPhys::cohesionDisablesFriction`)"))
+                ((shared_ptr<MatchMaker>,frictAngle,,,"Instance of :yref:`MatchMaker` determining how to compute interaction's friction angle. If ``None``, minimum value is used.")) // added from Frictphys.hpp
 		,
 		cohesionDefinitionIteration = -1;
 		);


### PR DESCRIPTION
Added frictionAngle Matchmaker to cohesive frictional contact law 
(based on Frictphys)
see https://answers.launchpad.net/yade/+question/670376

I don't really have any experience with the source code of Yade or C++. But I compiled it and it seems to work. An example:

CohFrictMat0=CohFrictMat(label='CohMat0',id=0,
                         density=2.6e3,young=1e8,
                         poisson=6e-1,frictionAngle=0.9,
                         alphaKr=-1, alphaKtw=-1,
                         etaRoll=-1, etaTwist=-1,
                         normalCohesion= 1e5 ,shearCohesion = 1e5,isCohesive=True)

CohFrictMat1=CohFrictMat(label='CohMat1',id=1,
                         density=2.6e3,young=1e8,
                         poisson=6e-1,frictionAngle=0.1,
                         alphaKr=-1, alphaKtw=-1,
                         etaRoll=-1, etaTwist=-1,
                         normalCohesion= 1e5 ,shearCohesion = 1e5,isCohesive=True)

frictAngleMatchMaker = MatchMaker(algo = 'max')

ID0 = O.bodies.append(sphere((0,0,0),0.5,material = CohFrictMat0))
ID1 = O.bodies.append(sphere((0,0,1),0.5,material = CohFrictMat1))

EnlargeDetectionRadius = 1.2
O.engines=[
    ## Resets forces and momenta the act on bodies
    ForceResetter(),

    ## Using bounding boxes find possible body collisions.
    InsertionSortCollider([
        Bo1_Sphere_Aabb(aabbEnlargeFactor = EnlargeDetectionRadius),
        Bo1_Facet_Aabb(),
        ]),

    # Interactions
    InteractionLoop(
        ## Create geometry information about each potential collision.
        [
        Ig2_Sphere_Sphere_ScGeom6D(interactionDetectionFactor = EnlargeDetectionRadius),
        Ig2_Facet_Sphere_ScGeom6D(),
        ],

        ## Create physical information about the interaction.
        [Ip2_CohFrictMat_CohFrictMat_CohFrictPhys(frictAngle = frictAngleMatchMaker)],
        ## Constitutive law
        [Law2_ScGeom6D_CohFrictPhys_CohesionMoment()],
    ),
    # Gravity
    NewtonIntegrator(gravity=(0,0,-9.81),damping=0.3)
 ]

O.run(1)
O.wait()

TanFA = O.interactions[ID0,ID1].phys.tangensOfFrictionAngle
FA = numpy.arctan(TanFA)

print('Friction Angle at Interaction : %1.2f'%FA)
